### PR TITLE
Identify Python tests based on any import from nose

### DIFF
--- a/test-case-mode.el
+++ b/test-case-mode.el
@@ -340,10 +340,10 @@ See `compilation-context-lines'."
                       :data ,(format "/* XPM */
 static char * data[] = {
 \"18 13 4 1\",
-\" 	c None\",
-\".	c %s\",
-\"x	c %s\",
-\"+	c %s\",
+\"  c None\",
+\". c %s\",
+\"x c %s\",
+\"+ c %s\",
 \"                  \",
 \"       +++++      \",
 \"      +.....+     \",
@@ -1534,7 +1534,8 @@ configured correctly.  The classpath is determined by
     ('name "PyUnit")
     ('supported (and (derived-mode-p 'python-mode)
                      (or (test-case-grep "\\_<import\s+unittest\\_>")
-                         (test-case-grep "\\_<import\s+nose\\_>"))))
+                         (test-case-grep "\\_<import\s+nose\\_>")
+                         (test-case-grep "\\_<from\s+nose\\_>"))))
     ('command (concat test-case-python-executable " "
                       (test-case-localname buffer-file-name)))
     ('save t)

--- a/test-case-mode.el
+++ b/test-case-mode.el
@@ -340,10 +340,10 @@ See `compilation-context-lines'."
                       :data ,(format "/* XPM */
 static char * data[] = {
 \"18 13 4 1\",
-\"  c None\",
-\". c %s\",
-\"x c %s\",
-\"+ c %s\",
+\" 	c None\",
+\".	c %s\",
+\"x	c %s\",
+\"+	c %s\",
 \"                  \",
 \"       +++++      \",
 \"      +.....+     \",


### PR DESCRIPTION
Hi,

I was hoping you could add this patch to support identifying a Python tests based on any import from nose.  For example:

from nose.tools import *

Thank you,